### PR TITLE
Enable building against Canonical's packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CONF   := pyxis.conf
 
 .PHONY: all install uninstall clean deb
 
-CPPFLAGS := -D_GNU_SOURCE -D_FORTIFY_SOURCE=2 $(CPPFLAGS)
+CPPFLAGS := -D_GNU_SOURCE -D_FORTIFY_SOURCE=2 -I/usr/include/slurm -I/usr/include/slurm-wlm $(CPPFLAGS)
 CFLAGS := -std=gnu11 -O2 -g -Wall -Wunused-variable -fstack-protector-strong -fpic $(CFLAGS)
 LDFLAGS := -Wl,-znoexecstack -Wl,-zrelro -Wl,-znow $(LDFLAGS)
 

--- a/pyxis_slurmd.c
+++ b/pyxis_slurmd.c
@@ -6,7 +6,7 @@
 #include <ftw.h>
 #include <string.h>
 
-#include <slurm/spank.h>
+#include <spank.h>
 
 #include "common.h"
 

--- a/pyxis_slurmstepd.c
+++ b/pyxis_slurmstepd.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <slurm/spank.h>
+#include <spank.h>
 
 #include "common.h"
 #include "seccomp_filter.h"


### PR DESCRIPTION
Their source package is called "slurm-llnl".

In their packages, they tend to call things "slurm-wlm" or "slurm-llnl"
instead of just "slurm".

https://packages.ubuntu.com/source/bionic/slurm-llnl