### PR TITLE
More verbose logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CPPFLAGS := -D_GNU_SOURCE -D_FORTIFY_SOURCE=2 -I/usr/include/slurm -I/usr/includ
 CFLAGS := -std=gnu11 -O2 -g -Wall -Wunused-variable -fstack-protector-strong -fpic $(CFLAGS)
 LDFLAGS := -Wl,-znoexecstack -Wl,-zrelro -Wl,-znow $(LDFLAGS)
 
-C_SRCS := pyxis_slurmstepd.c pyxis_slurmd.c
+C_SRCS := common.c pyxis_slurmstepd.c pyxis_slurmd.c
 C_OBJS := $(C_SRCS:.c=.o)
 
 DEPS := $(C_OBJS:%.o=%.d)

--- a/common.c
+++ b/common.c
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ */
+
 #include <stdlib.h>
 #include <string.h>
 
@@ -6,7 +10,7 @@
 char *get_line_from_file(FILE *fp)
 {
 	size_t len = 0;
-	char * line = NULL;
+	char *line = NULL;
 
 	if (getline(&line, &len, fp) == -1) {
 		free(line);
@@ -19,7 +23,7 @@ char *get_line_from_file(FILE *fp)
 	return line;
 }
 
-char *join_strings(char *const strings[], char *const sep)
+char *join_strings(char *const *strings, const char *sep)
 {
 	size_t strings_count, sep_len, result_len = 0;
 	char *result;
@@ -33,11 +37,12 @@ char *join_strings(char *const strings[], char *const sep)
 	sep_len = strlen(sep);
 	result_len += sep_len * (strings_count - 1) + 1;
 
-	result = calloc(1, result_len);
+	result = malloc(result_len);
 	if (result == NULL)
 		return NULL;
+	result[0] = '\0';
 
-	for (int i = 0; i < strings_count; ++i) {
+	for (size_t i = 0; i < strings_count; ++i) {
 		if (i != 0)
 			strncat(result, sep, sep_len);
 		strcat(result, strings[i]);

--- a/common.c
+++ b/common.c
@@ -1,0 +1,46 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "common.h"
+
+char *get_line_from_file(FILE *fp)
+{
+	size_t len = 0;
+	char * line = NULL;
+
+	if (getline(&line, &len, fp) == -1) {
+		free(line);
+		return NULL;
+	}
+
+	len = strlen(line);
+	if (len > 0 && line[len - 1] == '\n')
+		line[len - 1] = '\0'; /* trim trailing newline */
+	return line;
+}
+
+char *join_strings(char *const strings[], char *const sep)
+{
+	size_t strings_count, sep_len, result_len = 0;
+	char *result;
+
+	if (strings[0] == NULL)
+		return NULL;
+
+	for (strings_count = 0; strings[strings_count] != NULL; ++strings_count)
+		result_len += strlen(strings[strings_count]);
+
+	sep_len = strlen(sep);
+	result_len += sep_len * (strings_count - 1) + 1;
+
+	result = calloc(1, result_len);
+	if (result == NULL)
+		return NULL;
+
+	for (int i = 0; i < strings_count; ++i) {
+		if (i != 0)
+			strncat(result, sep, sep_len);
+		strcat(result, strings[i]);
+	}
+	return result;
+}

--- a/common.c
+++ b/common.c
@@ -23,7 +23,7 @@ char *get_line_from_file(FILE *fp)
 	return line;
 }
 
-char *join_strings(const char *const strings[], const char *sep)
+char *join_strings(char *const strings[], const char *sep)
 {
 	size_t strings_count, sep_len, result_len = 0;
 	char *result;

--- a/common.c
+++ b/common.c
@@ -23,7 +23,7 @@ char *get_line_from_file(FILE *fp)
 	return line;
 }
 
-char *join_strings(char *const *strings, const char *sep)
+char *join_strings(const char *const strings[], const char *sep)
 {
 	size_t strings_count, sep_len, result_len = 0;
 	char *result;

--- a/common.h
+++ b/common.h
@@ -34,6 +34,6 @@ static inline int pyxis_memfd_create(const char *name, unsigned int flags)
 
 char *get_line_from_file(FILE *);
 
-char *join_strings(char *const[], char *const);
+char *join_strings(char *const *, const char *);
 
 #endif /* COMMON_H_ */

--- a/common.h
+++ b/common.h
@@ -32,47 +32,8 @@ static inline int pyxis_memfd_create(const char *name, unsigned int flags)
 	return syscall(__NR_memfd_create, name, flags);
 }
 
-static char *get_line_from_file(FILE *fp)
-{
-	ssize_t read;
-	size_t len = 0;
-	char * line = NULL;
+char *get_line_from_file(FILE *);
 
-	if (getline(&line, &len, fp) == -1) {
-		free(line);
-		return NULL;
-	}
-
-	len = strlen(line);
-	if (len > 0 && line[len - 1] == '\n')
-		line[len - 1] = '\0'; /* trim trailing newline */
-	return line;
-}
-
-static char *join_strings(char *const strings[], char *const sep)
-{
-	size_t strings_count, sep_len, result_len = 0;
-	char *result;
-
-	if (strings[0] == NULL)
-		return NULL;
-
-	for (strings_count = 0; strings[strings_count] != NULL; ++strings_count)
-		result_len += strlen(strings[strings_count]);
-
-	sep_len = strlen(sep);
-	result_len += sep_len * (strings_count - 1) + 1;
-
-	result = calloc(1, result_len);
-	if (result == NULL)
-		return NULL;
-
-	for (int i = 0; i < strings_count; ++i) {
-		if (i != 0)
-			strncat(result, sep, sep_len);
-		strcat(result, strings[i]);
-	}
-	return result;
-}
+char *join_strings(char *const[], char *const);
 
 #endif /* COMMON_H_ */

--- a/common.h
+++ b/common.h
@@ -2,6 +2,7 @@
 #define COMMON_H_
 
 #include <unistd.h>
+#include <stdio.h>
 #include <sys/syscall.h>
 
 #define PYXIS_RUNTIME_PATH "/run/pyxis"
@@ -29,6 +30,49 @@ static inline void xclose(int fd)
 static inline int pyxis_memfd_create(const char *name, unsigned int flags)
 {
 	return syscall(__NR_memfd_create, name, flags);
+}
+
+static char *get_line_from_file(FILE *fp)
+{
+	ssize_t read;
+	size_t len = 0;
+	char * line = NULL;
+
+	if (getline(&line, &len, fp) == -1) {
+		free(line);
+		return NULL;
+	}
+
+	len = strlen(line);
+	if (len > 0 && line[len - 1] == '\n')
+		line[len - 1] = '\0'; /* trim trailing newline */
+	return line;
+}
+
+static char *join_strings(char *const strings[], char *const sep)
+{
+	size_t strings_count, sep_len, result_len = 0;
+	char *result;
+
+	if (strings[0] == NULL)
+		return NULL;
+
+	for (strings_count = 0; strings[strings_count] != NULL; ++strings_count)
+		result_len += strlen(strings[strings_count]);
+
+	sep_len = strlen(sep);
+	result_len += sep_len * (strings_count - 1) + 1;
+
+	result = calloc(1, result_len);
+	if (result == NULL)
+		return NULL;
+
+	for (int i = 0; i < strings_count; ++i) {
+		if (i != 0)
+			strncat(result, sep, sep_len);
+		strcat(result, strings[i]);
+	}
+	return result;
 }
 
 #endif /* COMMON_H_ */

--- a/common.h
+++ b/common.h
@@ -34,6 +34,6 @@ static inline int pyxis_memfd_create(const char *name, unsigned int flags)
 
 char *get_line_from_file(FILE *fp);
 
-char *join_strings(const char *const strings[], const char *sep);
+char *join_strings(char *const strings[], const char *sep);
 
 #endif /* COMMON_H_ */

--- a/common.h
+++ b/common.h
@@ -32,8 +32,8 @@ static inline int pyxis_memfd_create(const char *name, unsigned int flags)
 	return syscall(__NR_memfd_create, name, flags);
 }
 
-char *get_line_from_file(FILE *);
+char *get_line_from_file(FILE *fp);
 
-char *join_strings(char *const *, const char *);
+char *join_strings(const char *const strings[], const char *sep);
 
 #endif /* COMMON_H_ */

--- a/pyxis_slurmstepd.c
+++ b/pyxis_slurmstepd.c
@@ -551,10 +551,11 @@ static pid_t enroot_exec(uid_t uid, gid_t gid, char *const argv[])
 	int null_fd = -1;
 	int target_fd = -1;
 	pid_t pid;
+	char *argv_str;
 
 	enroot_reset_log();
 
-	char *argv_str = join_strings(argv, " ");
+	argv_str = join_strings(argv, " ");
 	if (argv_str != NULL) {
 		slurm_verbose("pyxis: running \"%s\" ...", argv_str);
 		free(argv_str);

--- a/pyxis_slurmstepd.c
+++ b/pyxis_slurmstepd.c
@@ -562,6 +562,9 @@ static char* join_strings(char *const strings[])
 		len += strlen(strings[i]);
 		len += 1;
 	}
+	if (len == 0)
+		return NULL;
+
 	result = malloc(len);
 	if (result == NULL)
 		return NULL;


### PR DESCRIPTION
 * Stop referencing enroot in `info` (SLURMD_DEBUG=1) messages
* Show enroot details in `verbose` (SLURMD_DEBUG=2) messages

BEFORE
```
$ SLURMD_DEBUG=2 srun --container-image=ubuntu true
slurmstepd: pyxis: running "enroot import" ...
slurmstepd: pyxis: running "enroot create" ...
slurmstepd: pyxis: running "enroot start" ...
```
AFTER
```
$ SLURMD_DEBUG=1 srun --container-image=ubuntu true
slurmstepd: pyxis: importing docker image ...
slurmstepd: pyxis: creating container filesystem ...
slurmstepd: pyxis: starting container ...

$ SLURMD_DEBUG=2 srun --container-image=ubuntu true
slurmstepd: pyxis: importing docker image ...
slurmstepd: pyxis: [verbose] running "enroot import --output /run/pyxis/1001/94.0.squashfs docker://ubuntu" ...
slurmstepd: pyxis: creating container filesystem ...
slurmstepd: pyxis: [verbose] running "enroot create --name 94.0 /run/pyxis/1001/94.0.squashfs" ...
slurmstepd: pyxis: starting container ...
slurmstepd: pyxis: [verbose] enroot start configuration script:
slurmstepd: pyxis:     mounts() {
slurmstepd: pyxis:      echo "none /tmp x-detach,nofail,silent"
slurmstepd: pyxis:      echo "/tmp /tmp x-create=dir,rw,bind,nosuid,nodev"
slurmstepd: pyxis:      echo "${PMIX_SERVER_TMPDIR:-/dev/null} ${PMIX_SERVER_TMPDIR:-/dev/null} x-create=dir,rw,bind,nofail,silent"
slurmstepd: pyxis:     }
slurmstepd: pyxis: [verbose] running "enroot start --root --rw --conf /proc/self/fd/21 94.0 sh -c kill -STOP $$ ; exit 0" ...
```