### PR TITLE
added clang format settings for project

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+BasedOnStyle: LLVM
+IndentWidth: 8
+TabWidth: 8
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+UseTab: ForContinuationAndIndentation
+BreakBeforeBraces: Linux
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false
+ColumnLimit: 110
+Cpp11BracedListStyle: false


### PR DESCRIPTION
Add a .clang-format file with settings that try to mirror formatting options currently used in the projet (use tabs, attach braces, but not for functions,...)

With this if clang-format is installed (and its companion git-clang-format), and one has staged all the changes then executing
  git clang-format
wil reformat the changes according to the style defined, and one can review the changes comparing staged and non staged changes.

Signed-off-by: Fawzi Mohamed <fawzi.mohamed@cscs.ch>