### PR TITLE
debian: allow slurm-smd to provide libslurm

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: NVIDIA CORPORATION <cudatools@nvidia.com>
 Standards-Version: 4.1.4
 Homepage: https://github.com/NVIDIA/pyxis
-Build-Depends: debhelper (>= 10), libslurm-dev
+Build-Depends: debhelper (>= 10), slurm-smd-dev | libslurm-dev
 
 Package: nvslurm-plugin-pyxis
 Architecture: any


### PR DESCRIPTION
Allow spank.h to be provided by either the official SchedMD packages (slurm-smd-dev) or by nephele-packages (libslurm-dev).