### PR TITLE
Packaging: add a dependency on Slurm version for RPM packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,14 @@ PLUGINDIR := $(abspath $(DESTDIR)/$(libdir)/slurm)
 CONFDIR   := $(abspath $(DESTDIR)/$(datadir)/pyxis)
 
 ARCH      ?= $(shell uname -m)
-VERSION   ?= 0.20.0
+PYXIS_VER ?= 0.20.0
 
 PLUGIN := spank_pyxis.so
 CONF   := pyxis.conf
 
 .PHONY: all install uninstall clean deb rpm
 
-CPPFLAGS := -D_GNU_SOURCE -D_FORTIFY_SOURCE=2 -DPYXIS_VERSION=\"$(VERSION)\" $(CPPFLAGS)
+CPPFLAGS := -D_GNU_SOURCE -D_FORTIFY_SOURCE=2 -DPYXIS_VERSION=\"$(PYXIS_VER)\" $(CPPFLAGS)
 CFLAGS := -std=gnu11 -O2 -g -Wall -Wunused-variable -fstack-protector-strong -fpic $(CFLAGS)
 LDFLAGS := -Wl,-znoexecstack -Wl,-zrelro -Wl,-znow $(LDFLAGS)
 
@@ -46,14 +46,14 @@ clean:
 	rm -rf $(C_OBJS) $(DEPS) $(PLUGIN)
 
 orig: clean
-	tar -caf ../nvslurm-plugin-pyxis_$(VERSION).orig.tar.xz --owner=root --group=root --exclude=.git .
+	tar -caf ../nvslurm-plugin-pyxis_$(PYXIS_VER).orig.tar.xz --owner=root --group=root --exclude=.git .
 
 deb: clean
 	debuild -us -uc -G -i -tc
 
 rpm: clean
 	test -e $(ARCH) || ln -s . $(ARCH)
-	rpmbuild --target=$(ARCH) --clean -ba -D"_topdir $(CURDIR)/rpm" -D"VERSION $(VERSION)" pyxis.spec
+	rpmbuild --target=$(ARCH) --clean -ba -D"_topdir $(CURDIR)/rpm" -D"PYXIS_VER $(PYXIS_VER)" pyxis.spec
 	$(RM) -r $(ARCH) $(addprefix rpm/, BUILDROOT SOURCES)
 
 -include $(DEPS)

--- a/pyxis.spec
+++ b/pyxis.spec
@@ -1,6 +1,8 @@
+%global slurm_version  %(rpm -q slurm-devel --qf "%{VERSION}" | awk -F. '{print "sl"$1$2"."}' 2>/dev/null)
+
 Name:           nvslurm-plugin-pyxis
-Version:        %{VERSION}
-Release:        1%{?dist}
+Version:        %{PYXIS_VER}
+Release:        %{slurm_version}1%{?dist}
 License:        ASL 2.0
 Vendor: NVIDIA CORPORATION
 Packager: NVIDIA CORPORATION <cudatools@nvidia.com>


### PR DESCRIPTION
Slurm SPANK plugins need to be recompiled for each major Slurm version. To make upgrades easier and avoid confusion, this PR proposes to add a dependency on the version of Slurm that's installed on the system, and add that major version in the generated RPM release info.

For instance, building RPMs for Pyxis 0.20 on a el9 host with Slurm 24.11 RPMs will create a `nvslurm-plugin-pyxis-0.20.0-slurm2411.1.el9.x86_64.rpm` package, with a dependency on `libslurm.so.42()(64bit)`.

To do this, we get the version of the installed `slurm-devel` RPM package in the SPEC file, via a `rpm -q` command. Doing this uses the "%{VERSION}" RPM tag, which conflicts with `VERSION` variable that is used in the `Makefile` and passed to `rpmbuild`. So to avoid unwanted expansion of that `%{VERSION}` variable, it's been renamed to `PYXIS_VER` in the Makefile.