### PR TITLE
Fix memory leak when retrieving header line in enroot list -r

### DIFF
--- a/pyxis_slurmstepd.c
+++ b/pyxis_slurmstepd.c
@@ -469,6 +469,8 @@ static int enroot_container_get(const char *name, pid_t *pid)
 		slurm_error("pyxis: \"enroot list -f\" did not produce any usable output");
 		goto fail;
 	}
+	free(line);
+	line = NULL;
 
 	while ((line = get_line_from_file(fp)) != NULL) {
 		ctr_name = strtok_r(line, " ", &saveptr);


### PR DESCRIPTION
In a commit 5f3f3a605e9 ("Reuse the namespaces of containers that are already running"), the first line of output of 'enroot list -r' command is retrieved but never freed, resulting in a memory leak.

This commit fixes the issue by properly releasing the allocated memory.

Fixes: 5f3f3a605e96 ("Reuse the namespaces of containers that are already running")