### PR TITLE
pyxis: add --container-cache persistent rootfs reuse + GC/LRU + tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ CPPFLAGS := -D_GNU_SOURCE -D_FORTIFY_SOURCE=2 -DPYXIS_VERSION=\"$(PYXIS_VER)\" $
 CFLAGS := -std=gnu11 -O2 -g -Wall -Wunused-variable -fstack-protector-strong -fpic $(CFLAGS)
 LDFLAGS := -Wl,-znoexecstack -Wl,-zrelro -Wl,-znow $(LDFLAGS)
 
+ifneq ($(strip $(SLURM_ROOT)),)
+CPPFLAGS += -I$(SLURM_ROOT)/include
+endif
+
 C_SRCS := common.c args.c pyxis_slurmstepd.c pyxis_slurmd.c pyxis_srun.c pyxis_alloc.c pyxis_dispatch.c config.c enroot.c importer.c
 C_OBJS := $(C_SRCS:.c=.o)
 

--- a/PLAN_CONTAINER_CACHE.md
+++ b/PLAN_CONTAINER_CACHE.md
@@ -1,0 +1,168 @@
+# Plan: `--container-cache` (Module 3A) — Persistent RootFS Reuse with Pyxis + Enroot
+
+This file is a working plan/spec for implementing and validating **Module 3A** in Pyxis:
+
+- New user-facing flag: `srun --container-cache`
+- Goal: reuse the **unpacked** Enroot rootfs across jobs on the **same node** to achieve near-1s warm starts
+- Constraints:
+  - Must work with the existing cluster cleanup behavior (Epilog deletes `pyxis_${SLURM_JOB_ID}*`)
+  - **Disallow** `--container-writable` and `--container-save` in cache mode (to avoid unsafe cross-job state)
+  - Must not require users to encode digest/version into `--container-name`
+
+---
+
+## Background / Why this exists
+
+On our cluster:
+- Cold start (`--container-name` first use) costs ~14–18s/node
+- Warm start can be ~1s **only if** the unpacked rootfs persists
+- Today rootfs does **not** persist across jobs because:
+  - job-scoped naming (`pyxis_${JOBID}_...`) and
+  - `/etc/slurm/epilog.d/70-enroot-container-cleanup.sh` removing `pyxis_${SLURM_JOB_ID}*`
+
+So we need a **Pyxis-native** mechanism to:
+1) generate stable cache identities and
+2) ensure the resulting rootfs directories do not match job-scoped cleanup patterns.
+
+---
+
+## Design summary
+
+### User interface
+
+- **Flag:** `--container-cache`
+  - Also available via env: `PYXIS_CONTAINER_CACHE=1`
+- When set:
+  - Requires `--container-image`
+  - Rejects `--container-writable`
+  - Rejects `--container-save`
+  - Forces read-only rootfs (`ENROOT_ROOTFS_WRITABLE=n`)
+
+### How caching works
+
+1) **Stable cache key** is derived from the image identity:
+   - For `.sqsh` paths: `abs_path + mtime + size` (fast; avoids hashing huge files)
+   - For non-path images: hash the image string (future improvement: OCI digest)
+
+2) **Stable container name** is auto-generated from the cache key:
+   - Example prefix: `pyxis_cache_<uid>_<hash>`
+   - **Important:** In cache mode, naming must be **non-job-scoped** (no jobid prefix).
+
+3) **Reuse behavior**
+   - If the container already exists: Pyxis reuses the filesystem and skips `enroot create`
+   - Otherwise: Pyxis creates it once (cold path), then it persists
+
+### Cache directory layout
+
+- **Required config for cache mode** (plugstack arg):
+  - `container_cache_data_path=/raid/containers/data`
+- **Per-user cache directory**:
+  - Pyxis creates/uses `<base>/<uid>` with mode `0700` and ownership `<uid>:<gid>`
+  - For cache mode, Pyxis sets `ENROOT_DATA_PATH=<base>/<uid>` for all Enroot calls
+- **Cached rootfs directory name**:
+  - `pyxis_cache_u<uid>_<hash>`
+  - Full path: `<base>/<uid>/pyxis_cache_u<uid>_<hash>`
+- **Locking + "last used" signal**:
+  - Pyxis creates `<rootfs>/.pyxis_cache_lock`
+    - jobs hold a **shared** lock for the job lifetime
+    - GC tries an **exclusive non-blocking** lock; if it can’t lock, the entry is treated as in-use
+  - Each time a cached rootfs is used, Pyxis `touch`es the rootfs directory to update its `mtime`
+    - GC uses this `mtime` as the LRU timestamp (no reliance on filesystem `atime`)
+
+### GC / LRU eviction (global across users)
+
+Goal: prevent jobs failing due to the cache filesystem being full.
+
+- **When GC runs**:
+  - Opportunistic, at job start in cache mode **only if** we’re about to create a new cached rootfs (cold path)
+  - Reuse path should not trigger GC
+- **Watermarks** (admin-configurable):
+  - `container_cache_gc_high=85` (default): start evicting when used% is \(\ge\) high
+  - `container_cache_gc_low=80` (default): stop evicting when used% drops below low
+- **Global serialization**:
+  - GC takes an exclusive lock on `<base>/pyxis-container-cache-gc.lock` so multiple jobs don’t evict concurrently
+- **Candidate selection (LRU)**:
+  - Scan all user dirs: `<base>/*/pyxis_cache_*`
+  - Sort candidates by directory `mtime` (oldest first)
+- **Eviction loop**:
+  - For each candidate, try to acquire an **exclusive non-blocking** lock on `<candidate>/.pyxis_cache_lock`
+    - if locked: recursively delete the candidate directory
+    - if not lockable: skip (in-use)
+  - Re-check used% and stop once below `container_cache_gc_low`
+- **Cross-user behavior**:
+  - Because `<base>/<uid>` is `0700`, GC must run in a privileged SPANK hook so it can traverse/evict other users’ entries.
+
+---
+
+## Code changes (high-level)
+
+### 1) Add new flag and env var plumbing
+- `args.h`: add `int container_cache;`
+- `args.c`:
+  - register `--container-cache`
+  - parse `PYXIS_CONTAINER_CACHE`
+
+### 2) Implement cache mode in `pyxis_slurmstepd.c`
+- During `slurm_spank_user_init`:
+  - validate incompatible flags (`--container-writable`, `--container-save`)
+  - compute stable name
+  - force `container_scope=global` for cache mode
+  - derive a per-user cache directory from `container_cache_data_path` (`<base>/<uid>`)
+
+- During Enroot execution (`enroot_set_env`):
+  - set `ENROOT_DATA_PATH` for cache mode (`<base>/<uid>`)
+
+- During container create:
+  - run GC if needed (global `/raid` thresholds)
+  - touch/lock cached entries to prevent eviction while in-use
+
+### 3) Config knobs
+Extend `config.[ch]` to parse:
+- `container_cache_data_path=...`
+- `container_cache_gc_high=...`
+- `container_cache_gc_low=...`
+
+---
+
+## Testing plan (cluster)
+
+### Automated (BATS)
+- Ensure Slurm env is set (cluster-specific; adjust paths as needed):
+
+```bash
+export SLURM_ROOT=/cm/local/apps/slurm/24.11
+export PATH="$SLURM_ROOT/bin:$SLURM_ROOT/sbin:$PATH"
+export LD_LIBRARY_PATH="$SLURM_ROOT/lib64:${LD_LIBRARY_PATH:-}"
+export SLURM_CONF=/etc/slurm/slurm.conf
+```
+
+- Run: `bats tests/container_cache.bats`
+  - Covers: policy enforcement, stable naming/layout under `<base>/<uid>`, read-only enforcement, env var enablement, and GC behavior (including cross-user eviction) when usage is above the configured high watermark.
+  - If needed: `PYXIS_TEST_SQSH_IMAGE=/path/to/image.sqsh bats tests/container_cache.bats`
+
+### Functional correctness (manual)
+1) Cold create:
+   - `srun --container-cache --container-image=<image> ...`
+   - expect: rootfs directory `<base>/<uid>/pyxis_cache_u<uid>_<hash>` is created
+2) Warm reuse (separate job, same node):
+   - run the same command on the same node
+   - expect: the same cached rootfs is reused (near-1s startup)
+
+### Cleanup compatibility
+- Verify cached directories are **non-job-scoped** (e.g. `pyxis_cache_u<uid>_*`) and do **not** match Epilog `pyxis_${JOBID}*` patterns.
+
+### GC/LRU (manual)
+- Trigger GC by filling the cache filesystem above `container_cache_gc_high`, then create new cached rootfs entries.
+- Confirm oldest caches are evicted first and locked/in-use caches are not evicted.
+
+---
+
+## Open items / future improvements
+
+- Use image digest for OCI images (instead of hashing only the image string)
+- More robust last-used tracking (avoid relying on directory `mtime`)
+- Expand test coverage for concurrency/stress scenarios on a multi-node cluster
+
+---
+
+

--- a/args.h
+++ b/args.h
@@ -17,6 +17,7 @@ struct plugin_args {
 	char *workdir;
 	char *container_name;
 	char *container_name_flags;
+	int container_cache;
 	char *container_save;
 	int mount_home;
 	int remap_root;

--- a/config.h
+++ b/config.h
@@ -20,6 +20,9 @@ struct plugin_config {
 	bool sbatch_support;
 	bool use_enroot_load;
 	char importer_path[PATH_MAX];
+	char container_cache_data_path[PATH_MAX];
+	int container_cache_gc_high;
+	int container_cache_gc_low;
 };
 
 int pyxis_config_parse(struct plugin_config *config, int ac, char **av);

--- a/tests/container_cache.bats
+++ b/tests/container_cache.bats
@@ -1,0 +1,386 @@
+#!/usr/bin/env bats
+
+load ./common
+
+function _test_image() {
+    local img="${PYXIS_TEST_SQSH_IMAGE:-/home/horde/vsabavat-code/enroot/ubuntu+latest.sqsh}"
+    if [ ! -f "${img}" ]; then
+        skip "set PYXIS_TEST_SQSH_IMAGE to a local .sqsh image path"
+    fi
+    echo "${img}"
+}
+
+function _cache_root() {
+    if [ -n "${PYXIS_TEST_CACHE_ROOT:-}" ]; then
+        echo "${PYXIS_TEST_CACHE_ROOT}"
+        return 0
+    fi
+    if [ -r /opt/slurm-test/etc/plugstack.conf ]; then
+        sed -n 's/.*container_cache_data_path=\([^ ]*\).*/\1/p' /opt/slurm-test/etc/plugstack.conf | head -n1
+        return 0
+    fi
+    echo "/tmp/enroot-data"
+}
+
+function _gc_high() {
+    if [ -n "${PYXIS_TEST_GC_HIGH:-}" ]; then
+        echo "${PYXIS_TEST_GC_HIGH}"
+        return 0
+    fi
+    if [ -r /opt/slurm-test/etc/plugstack.conf ]; then
+        local v
+        v="$(sed -n 's/.*container_cache_gc_high=\([^ ]*\).*/\1/p' /opt/slurm-test/etc/plugstack.conf | head -n1)"
+        if [ -n "${v}" ]; then
+            echo "${v}"
+            return 0
+        fi
+    fi
+    echo "85"
+}
+
+function _gc_low() {
+    if [ -n "${PYXIS_TEST_GC_LOW:-}" ]; then
+        echo "${PYXIS_TEST_GC_LOW}"
+        return 0
+    fi
+    if [ -r /opt/slurm-test/etc/plugstack.conf ]; then
+        local v
+        v="$(sed -n 's/.*container_cache_gc_low=\([^ ]*\).*/\1/p' /opt/slurm-test/etc/plugstack.conf | head -n1)"
+        if [ -n "${v}" ]; then
+            echo "${v}"
+            return 0
+        fi
+    fi
+    echo "80"
+}
+
+function _mkimglink() {
+    local target="$1"
+    local link
+    link="$(mktemp -p /tmp pyxis-cache-img.XXXXXX.sqsh)"
+    rm -f "${link}"
+    ln -s "${target}" "${link}"
+    echo "${link}"
+}
+
+function _cache_container_name_for_image() {
+    local image="$1"
+    local uid
+    uid="$(id -u)"
+    python3 - "${image}" "${uid}" <<'PY'
+import os, sys
+
+image = sys.argv[1]
+uid = int(sys.argv[2])
+
+FNV_OFFSET = 1469598103934665603
+FNV_PRIME = 1099511628211
+MASK = (1 << 64) - 1
+
+def fnv1a64_update(h: int, data: bytes) -> int:
+    for b in data:
+        h ^= b
+        h = (h * FNV_PRIME) & MASK
+    return h
+
+h = FNV_OFFSET
+h = fnv1a64_update(h, image.encode())
+
+if image and image[0] in ('.', '/'):
+    try:
+        st = os.stat(image)
+        extra = f"|{int(st.st_mtime)}|{int(st.st_size)}".encode()
+        h = fnv1a64_update(h, extra)
+    except FileNotFoundError:
+        pass
+
+print(f"pyxis_cache_u{uid}_{h:016x}")
+PY
+}
+
+function _cache_container_dir_for_image() {
+    local image="$1"
+    local uid
+    uid="$(id -u)"
+    local root
+    root="$(_cache_root)"
+    echo "${root}/${uid}/$(_cache_container_name_for_image "${image}")"
+}
+
+function _cleanup_cache_for_image() {
+    local image="$1"
+    local dir
+    dir="$(_cache_container_dir_for_image "${image}")"
+    rm -rf "${dir}" || true
+}
+
+function setup() {
+    unset PYXIS_DEBUG || true
+}
+
+function teardown() {
+    unset PYXIS_DEBUG || true
+}
+
+@test "--container-cache is incompatible with --container-writable" {
+    local img link
+    img="$(_test_image)"
+    link="$(_mkimglink "${img}")"
+
+    run_srun_unchecked --container-cache --container-image="${link}" --container-writable true
+    [ "${status}" -ne 0 ]
+    [[ "${output}" == *"--container-cache is incompatible with --container-writable"* ]]
+
+    _cleanup_cache_for_image "${link}"
+    rm -f "${link}" || true
+}
+
+@test "--container-cache is incompatible with --container-save" {
+    local img link
+    img="$(_test_image)"
+    link="$(_mkimglink "${img}")"
+
+    run_srun_unchecked --container-cache --container-image="${link}" --container-save=/tmp/pyxis-cache-test.sqsh true
+    [ "${status}" -ne 0 ]
+    [[ "${output}" == *"--container-cache is incompatible with --container-save"* ]]
+
+    _cleanup_cache_for_image "${link}"
+    rm -f "${link}" || true
+}
+
+@test "--container-cache requires --container-image" {
+    run_srun_unchecked --container-cache true
+    [ "${status}" -ne 0 ]
+    [[ "${output}" == *"--container-cache requires --container-image"* ]]
+}
+
+@test "--container-cache is incompatible with --container-name flags" {
+    local img link
+    img="$(_test_image)"
+    link="$(_mkimglink "${img}")"
+
+    run_srun_unchecked --container-cache --container-image="${link}" --container-name=cache-test:exec true
+    [ "${status}" -ne 0 ]
+    [[ "${output}" == *"--container-cache is incompatible with --container-name flags"* ]]
+
+    _cleanup_cache_for_image "${link}"
+    rm -f "${link}" || true
+}
+
+@test "--container-cache creates a stable pyxis_cache_u<uid>_* rootfs under container_cache_data_path" {
+    local img link uid root name dir
+    img="$(_test_image)"
+    link="$(_mkimglink "${img}")"
+
+    uid="$(id -u)"
+    root="$(_cache_root)"
+    name="$(_cache_container_name_for_image "${link}")"
+    dir="$(_cache_container_dir_for_image "${link}")"
+
+    rm -rf "${dir}" || true
+
+    run_srun --container-cache --container-image="${link}" true
+
+    [ -d "${dir}" ]
+    [ -f "${dir}/.pyxis_cache_lock" ]
+    [ "$(stat -c %a "${root}/${uid}")" = "700" ]
+    [ "$(stat -c %u "${root}/${uid}")" = "${uid}" ]
+    [[ "${name}" == "pyxis_cache_u${uid}_"* ]]
+    [[ "${dir}" == "${root}/${uid}/"* ]]
+
+    _cleanup_cache_for_image "${link}"
+    rm -f "${link}" || true
+}
+
+@test "--container-cache ignores plain --container-name (stable name is still used)" {
+    local img link uid root stable_dir ignored_name ignored_dir
+    img="$(_test_image)"
+    link="$(_mkimglink "${img}")"
+
+    uid="$(id -u)"
+    root="$(_cache_root)"
+
+    ignored_name="cache-name-ignored-${RANDOM}"
+    ignored_dir="${root}/${uid}/pyxis_${ignored_name}"
+    stable_dir="$(_cache_container_dir_for_image "${link}")"
+
+    rm -rf "${ignored_dir}" "${stable_dir}" || true
+
+    run_srun --container-cache --container-image="${link}" --container-name="${ignored_name}" true
+
+    [ -d "${stable_dir}" ]
+    [ ! -e "${ignored_dir}" ]
+
+    _cleanup_cache_for_image "${link}"
+    rm -f "${link}" || true
+}
+
+@test "--container-cache forces a read-only rootfs (even with --container-remap-root)" {
+    local img link
+    img="$(_test_image)"
+    link="$(_mkimglink "${img}")"
+
+    run_srun_unchecked --container-cache --container-image="${link}" --container-remap-root sh -c 'touch /pyxis_ro_test'
+    [ "${status}" -ne 0 ]
+    [[ "${output}" == *"Read-only file system"* ]]
+
+    _cleanup_cache_for_image "${link}"
+    rm -f "${link}" || true
+}
+
+@test "container-cache GC does not evict cache entries that are locked/in-use" {
+    if ! command -v flock >/dev/null 2>&1; then
+        skip "flock not available"
+    fi
+
+    local img link uid root cache_dir locked_dir unlocked_dir lock_file lock_pid
+    img="$(_test_image)"
+    link="$(_mkimglink "${img}")"
+
+    uid="$(id -u)"
+    root="$(_cache_root)"
+    cache_dir="${root}/${uid}"
+
+    mkdir -p "${cache_dir}"
+
+    local high used_pct
+    high="$(_gc_high)"
+    used_pct="$(python3 - "${cache_dir}" <<'PY'
+import os
+import sys
+
+path = sys.argv[1]
+st = os.statvfs(path)
+total = st.f_blocks * st.f_frsize
+avail = st.f_bavail * st.f_frsize
+used = total - avail
+pct = int((used * 100) // total) if total else 0
+print(pct)
+PY
+)"
+    if [ "${used_pct}" -lt "${high}" ]; then
+        rm -f "${link}" || true
+        skip "cache fs usage ${used_pct}% < ${high}% (GC won't run)"
+    fi
+
+    locked_dir="${cache_dir}/pyxis_cache_u${uid}_lockedtest_${RANDOM}"
+    unlocked_dir="${cache_dir}/pyxis_cache_u${uid}_unlockedtest_${RANDOM}"
+
+    mkdir -p "${locked_dir}" "${unlocked_dir}"
+    lock_file="${locked_dir}/.pyxis_cache_lock"
+    : > "${lock_file}"
+
+    touch -d "1970-01-01 00:00:00" "${locked_dir}" 2>/dev/null || true
+    touch -d "1970-01-01 00:00:01" "${unlocked_dir}" 2>/dev/null || true
+
+    flock -s "${lock_file}" -c 'sleep 300' &
+    lock_pid=$!
+
+    run_srun --container-cache --container-image="${link}" true
+
+    kill "${lock_pid}" >/dev/null 2>&1 || true
+    wait "${lock_pid}" >/dev/null 2>&1 || true
+
+    [ -d "${locked_dir}" ]
+    [ ! -e "${unlocked_dir}" ]
+
+    rm -rf "${locked_dir}" || true
+    _cleanup_cache_for_image "${link}"
+    rm -f "${link}" || true
+}
+
+@test "container-cache GC can evict entries in other user dirs when space is tight" {
+    local img link uid root high used_pct other_uid other_dir victim
+    img="$(_test_image)"
+    link="$(_mkimglink "${img}")"
+
+    uid="$(id -u)"
+    root="$(_cache_root)"
+    high="$(_gc_high)"
+
+    used_pct="$(python3 - "${root}" <<'PY'
+import os
+import sys
+
+path = sys.argv[1]
+st = os.statvfs(path)
+total = st.f_blocks * st.f_frsize
+avail = st.f_bavail * st.f_frsize
+used = total - avail
+pct = int((used * 100) // total) if total else 0
+print(pct)
+PY
+)"
+    if [ "${used_pct}" -lt "${high}" ]; then
+        _cleanup_cache_for_image "${link}"
+        rm -f "${link}" || true
+        skip "cache fs usage ${used_pct}% < ${high}% (GC won't run)"
+    fi
+
+    other_uid="9999${RANDOM}"
+    other_dir="${root}/${other_uid}"
+    victim="${other_dir}/pyxis_cache_u${other_uid}_victim_${RANDOM}"
+
+    cleanup() {
+        chmod 700 "${other_dir}" 2>/dev/null || true
+        rm -rf "${other_dir}" 2>/dev/null || true
+        _cleanup_cache_for_image "${link}" 2>/dev/null || true
+        rm -f "${link}" 2>/dev/null || true
+    }
+    trap cleanup EXIT
+
+    if ! mkdir -p "${victim}"; then
+        skip "cannot create ${victim} (cache root not writable?)"
+    fi
+    : > "${victim}/.pyxis_cache_lock"
+    touch -d "1970-01-01 00:00:00" "${victim}" 2>/dev/null || true
+    chmod 000 "${other_dir}" 2>/dev/null || true
+
+    run_srun --container-cache --container-image="${link}" true
+
+    chmod 700 "${other_dir}" 2>/dev/null || true
+    [ ! -e "${victim}" ]
+}
+
+@test "container-cache uses a stable rootfs directory name across runs" {
+    local img link container_dir
+    img="$(_test_image)"
+    link="$(_mkimglink "${img}")"
+
+    container_dir="$(_cache_container_dir_for_image "${link}")"
+    rm -rf "${container_dir}" || true
+
+    run_srun --container-cache --container-image="${link}" true
+    [ -d "${container_dir}" ]
+
+    run_srun --container-cache --container-image="${link}" true
+    [ -d "${container_dir}" ]
+
+    _cleanup_cache_for_image "${link}"
+    rm -f "${link}" || true
+}
+
+@test "PYXIS_CONTAINER_CACHE=1 enables cache mode (no --container-cache flag needed)" {
+    local img link uid root name dir
+    img="$(_test_image)"
+    link="$(_mkimglink "${img}")"
+
+    uid="$(id -u)"
+    root="$(_cache_root)"
+    name="$(_cache_container_name_for_image "${link}")"
+    dir="$(_cache_container_dir_for_image "${link}")"
+
+    rm -rf "${dir}" || true
+
+    export PYXIS_CONTAINER_CACHE=1
+    run_srun --container-image="${link}" true
+    unset PYXIS_CONTAINER_CACHE
+
+    [ -d "${dir}" ]
+    [[ "${name}" == "pyxis_cache_u${uid}_"* ]]
+
+    _cleanup_cache_for_image "${link}"
+    rm -f "${link}" || true
+}
+
+


### PR DESCRIPTION
## Summary
This PR adds **`--container-cache`** to Pyxis to enable **persistent reuse of the unpacked Enroot rootfs across jobs on the same node**, reducing warm-start latency.

It also introduces **opportunistic GC/LRU eviction** for cache entries to prevent the cache filesystem from filling up, and adds a **Bats** test suite for cache-mode behavior.

## User-facing behavior
- New flag: `srun --container-cache` (also `PYXIS_CONTAINER_CACHE=1`)
- Cache mode:
  - Requires `--container-image`
  - Rejects `--container-writable` and `--container-save`
  - Forces read-only rootfs (`ENROOT_ROOTFS_WRITABLE=n`)
  - Derives a stable cached container name: `pyxis_cache_u<uid>_<hash>`
  - Uses non-job-scoped naming so it survives Epilog cleanup patterns

## Configuration
Cache mode requires an explicit cache root configured via plugstack:

- `container_cache_data_path=/raid/containers/data` (required for cache mode)
- Optional GC tuning:
  - `container_cache_gc_high=85`
  - `container_cache_gc_low=80`

Example (cluster-specific):

required /path/to/spank_pyxis.so container_cache_data_path=/raid/containers/data container_cache_gc_high=85 container_cache_gc_low=80## Cache directory layout
- Cache root: `<base>` = `container_cache_data_path`
- Per-user Enroot data dir: `<base>/<uid>` (mode `0700`, owned by `<uid>:<gid>`)
- Cached rootfs: `<base>/<uid>/pyxis_cache_u<uid>_<hash>`
- Pyxis sets `ENROOT_DATA_PATH=<base>/<uid>` for cache mode.

## GC / LRU eviction
- Triggered opportunistically at job start in cache mode **only when we’re about to create a new cached rootfs** (cold path).
- Uses high/low watermarks to decide when to evict.
- Candidate selection:
  - Scans `<base>/*/pyxis_cache_*` (global across users)
  - Uses directory `mtime` as LRU (Pyxis touches the dir on use)
- Safety:
  - Each cached rootfs has `.pyxis_cache_lock`
  - Jobs hold a shared lock for their lifetime
  - GC attempts an exclusive non-blocking lock; if it can’t lock, it treats the entry as in-use and skips it
  - GC is serialized with `<base>/pyxis-container-cache-gc.lock`

## Tests
- Added `bats tests/container_cache.bats` for:
  - Policy enforcement (writable/save/name-flags)
  - Stable naming/layout under `<base>/<uid>`
  - Read-only enforcement
  - Env var enablement (`PYXIS_CONTAINER_CACHE=1`)
  - GC behavior (including cross-user eviction) when the cache filesystem is above the configured high watermark

To run tests (cluster-specific; adjust paths as needed):

export SLURM_ROOT=/cm/local/apps/slurm/24.11
export PATH="$SLURM_ROOT/bin:$SLURM_ROOT/sbin:$PATH"
export LD_LIBRARY_PATH="$SLURM_ROOT/lib64:${LD_LIBRARY_PATH:-}"
export SLURM_CONF=/etc/slurm/slurm.conf

bats tests/container_cache.bats(Optional if your squashfs image differs: `PYXIS_TEST_SQSH_IMAGE=/path/to/image.sqsh bats tests/container_cache.bats`)